### PR TITLE
fixing bug: a valid file path was not being used

### DIFF
--- a/lib/build-shim.js
+++ b/lib/build-shim.js
@@ -79,6 +79,7 @@ module.exports = function (dependencies, opts, exclude) {
       var isAMD = false;
       _.forOwn(parse(dep, name, opts.baseUrl || '').paths, function (fileName) {
 
+        fileName = path.join(opts.baseUrl, fileName);
         var ast = parser(fs.readFileSync(require.resolve(fileName), {encoding: 'utf-8'}), {tolerant: true});
 
         traverseAST(ast, function (node) {
@@ -96,7 +97,7 @@ module.exports = function (dependencies, opts, exclude) {
         });
 
       });
-      
+
       if (!isAMD) {
         shim[filterName(name, 'js', 'min')] = {deps: _.keys(dep.dependencies)};
       }


### PR DESCRIPTION
fixing bug: a valid file path was not being used when calling `require.resolve`, which caused it to silently fail and not create a shim entry