### PR TITLE
bug + optimization

### DIFF
--- a/lib/build-shim.js
+++ b/lib/build-shim.js
@@ -3,10 +3,10 @@ var _ = require('lodash');
 var slice = Array.prototype.slice;
 var chalk = require('chalk');
 var warn = chalk.black.bgYellow;
-var parser = require('acorn').parse;
 var fs = require('fs');
 var path = require('path');
 var parse = require('./parse');
+var moduleType = require('js-module-formats');
 
 /**
  * Build requirejs shim object from bower dependencies object.
@@ -33,33 +33,6 @@ module.exports = function (dependencies, opts, exclude) {
 
     return newName;
   }
-  function isDefine(node) {
-    var c = node.callee;
-    return c
-        && node.type === 'CallExpression'
-        && c.type === 'Identifier'
-        && c.name === 'define'
-    ;
-  }
-  function traverseAST(node, cb) {
-    if (Array.isArray(node)) {
-      node.forEach(function (x) {
-        if(x != null) {
-          x.parent = node;
-          traverseAST(x, cb);
-        }
-      });
-    }
-    else if (node && typeof node === 'object') {
-      cb(node);
-
-      Object.keys(node).forEach(function (key) {
-        if (key === 'parent' || !node[key]) return;
-        node[key].parent = node;
-        traverseAST(node[key], cb);
-      });
-    }
-  }
   if (opts['simple-shim']) {
     _.forOwn(dependencies, function (dep, name) {
       if ((opts['shim-all'] || (opts.shim && _.contains(opts.shim, name))) &&
@@ -80,22 +53,7 @@ module.exports = function (dependencies, opts, exclude) {
       _.forOwn(parse(dep, name, opts.baseUrl || '').paths, function (fileName) {
 
         fileName = path.join(opts.baseUrl, fileName);
-        var ast = parser(fs.readFileSync(require.resolve(fileName), {encoding: 'utf-8'}), {tolerant: true});
-
-        traverseAST(ast, function (node) {
-          if (isDefine(node)) {
-
-            if (node.arguments.length) {
-              if (
-              (node.arguments[0].type === 'Literal' && node.arguments[1].type === 'ArrayExpression' && node.arguments[2].type === 'FunctionExpression') ||
-              (node.arguments[0].type === 'ArrayExpression' && node.arguments[1].type === 'FunctionExpression')) {
-                isAMD = true;
-              }
-            }
-          }
-
-        });
-
+        isAMD = moduleType.detect(fs.readFileSync(require.resolve(fileName)));
       });
 
       if (!isAMD) {

--- a/lib/build-shim.js
+++ b/lib/build-shim.js
@@ -79,6 +79,7 @@ module.exports = function (dependencies, opts, exclude) {
       var isAMD = false;
       _.forOwn(parse(dep, name, opts.baseUrl || '').paths, function (fileName) {
 
+        fileName = path.join(opts.baseUrl, fileName);
         var ast = parser(fs.readFileSync(require.resolve(fileName), {encoding: 'utf-8'}), {tolerant: true});
 
         traverseAST(ast, function (node) {
@@ -96,7 +97,7 @@ module.exports = function (dependencies, opts, exclude) {
         });
 
       });
-      
+
       if (!isAMD) {
         shim[filterName(name, 'js', 'min')] = {deps: _.keys(dep.dependencies)};
       }

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "acorn": "^0.11.0",
     "chalk": "^0.5.1",
     "file-utils": "^0.2.1",
     "glob": "^4.0.2",
+    "js-module-formats": "^0.1.2",
     "lodash": "^2.4.1",
     "nopt": "^3.0.0",
     "object-assign": "^1.0.0",


### PR DESCRIPTION
- fixing bug: a valid file path was not being used when calling require.resolve, which caused it to silently fail and not create a shim entry
- using js-module-formats to identify non-AMD modules
- removing the `traverseAST` and `isDefine` helper functions, since they are no longer used